### PR TITLE
Fix affected_streams when stream name is changed

### DIFF
--- a/accurev.py
+++ b/accurev.py
@@ -2190,7 +2190,8 @@ class ext(object):
         
         rv = None
 
-        destStream = transaction.affectedStream()[0]
+        destStreamNum = transaction.affectedStream()[1]
+        destStream = show.streams(depot=depot, timeSpec=transaction.id, stream=destStreamNum).streams[0].name
 
         if destStream is not None:
             streamMap = ext.stream_dict(depot=depot, transaction=transaction.id)


### PR DESCRIPTION
Match by using the stream number returned by transaction.affectedStream()
and then looking up the stream name at the time of the transaction, using
the stream number returned by transaction.affectedStream(). The stream
name returned by that function is the current name.